### PR TITLE
DHX-29 (#17) - package `javax.xml.bind.annotation` does not exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ addons:
   apt:
     packages:
     - xmlstarlet
-jdk:
-- openjdk8
+matrix:
+  include:
+    # 8
+    - jdk: openjdk8
+    # 11
+    - jdk: openjdk11
+      script: mvn clean verify -q -P jdk11
 branches:
   only:
   - master

--- a/dhx-adapter-core/src/main/java/ee/ria/dhx/util/FileUtil.java
+++ b/dhx-adapter-core/src/main/java/ee/ria/dhx/util/FileUtil.java
@@ -365,9 +365,8 @@ public class FileUtil {
    /**
     * Test if a file is a zip file.
     * 
-    * @param f
-    *            the file to test.
-    * @return
+    * @param f the file to test.
+    * @return - true if file is zip file. Otherwise false.
     */
    public static boolean isZipFile(File f) {
    

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/service/util/Base64.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/service/util/Base64.java
@@ -41,7 +41,7 @@ import java.util.Objects;
  * <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>.
  *
  * <ul>
- * <li><a name="basic"><b>Basic</b></a>
+ * <li><a id="basic"><b>Basic</b></a>
  * <p>
  * Uses "The Base64 Alphabet" as specified in Table 1 of RFC 4648 and RFC 2045 for encoding and
  * decoding operation. The encoder does not add any line feed (line separator) character. The
@@ -49,7 +49,7 @@ import java.util.Objects;
  * </p>
  * </li>
  *
- * <li><a name="url"><b>URL and Filename safe</b></a>
+ * <li><a id="url"><b>URL and Filename safe</b></a>
  * <p>
  * Uses the "URL and Filename safe Base64 Alphabet" as specified in Table 2 of RFC 4648 for encoding
  * and decoding. The encoder does not add any line feed (line separator) character. The decoder
@@ -57,7 +57,7 @@ import java.util.Objects;
  * </p>
  * </li>
  *
- * <li><a name="mime"><b>MIME</b></a>
+ * <li><a id="mime"><b>MIME</b></a>
  * <p>
  * Uses the "The Base64 Alphabet" as specified in Table 1 of RFC 2045 for encoding and decoding
  * operation. The encoded output must be represented in lines of no more than 76 characters each and

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/service/util/StreamTypeEnum.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/service/util/StreamTypeEnum.java
@@ -3,7 +3,7 @@ package ee.ria.dhx.server.service.util;
 /**
  * Enumeration of the stream types.
  * 
- * @author 
+ * @author Tarmo Kalda
  *
  */
 public enum StreamTypeEnum {

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/service/util/WsUtil.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/service/util/WsUtil.java
@@ -61,6 +61,7 @@ public class WsUtil {
    * Creates InputStream that will GZIP decompress the stream from input.
    * 
    * @param stream stream to decompress
+   * @param stremType Stream type
    * @return decompressed stream
    * @throws DhxException thrown if error occurs
    */

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/ee/riik/xrd/dhl/producers/producer/dhl/GetSendingOptionsV3ResponseTypeUnencoded.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/ee/riik/xrd/dhl/producers/producer/dhl/GetSendingOptionsV3ResponseTypeUnencoded.java
@@ -136,12 +136,10 @@ public class GetSendingOptionsV3ResponseTypeUnencoded {
 
     /**
      * Gets the value of the asutused property.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused }
-     *     
-     * @return possible object is {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused }
      * 
      */
     public GetSendingOptionsV3ResponseTypeUnencoded.Asutused getAsutused() {
@@ -162,12 +160,10 @@ public class GetSendingOptionsV3ResponseTypeUnencoded {
 
     /**
      * Gets the value of the allyksused property.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link GetSendingOptionsV3ResponseTypeUnencoded.Allyksused }
-     *     
-     * @return possible object is {@link GetSendingOptionsV3ResponseTypeUnencoded.Allyksused }
      * 
      */
     public GetSendingOptionsV3ResponseTypeUnencoded.Allyksused getAllyksused() {
@@ -188,12 +184,10 @@ public class GetSendingOptionsV3ResponseTypeUnencoded {
 
     /**
      * Gets the value of the ametikohad property.
-     * 
+     *
      * @return
      *     possible object is
      *     {@link GetSendingOptionsV3ResponseTypeUnencoded.Ametikohad }
-     *     
-     * @return possible object is {@link GetSendingOptionsV3ResponseTypeUnencoded.Ametikohad }
      * 
      */
     public GetSendingOptionsV3ResponseTypeUnencoded.Ametikohad getAmetikohad() {

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/ee/riik/xrd/dhl/producers/producer/dhl/ObjectFactory.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/ee/riik/xrd/dhl/producers/producer/dhl/ObjectFactory.java
@@ -73,7 +73,8 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link GetSendingOptionsV3ResponseTypeUnencoded }
-   * 
+   *
+   * @return {@link GetSendingOptionsV3ResponseTypeUnencoded}
    */
   public GetSendingOptionsV3ResponseTypeUnencoded createGetSendingOptionsV3ResponseTypeUnencoded() {
       return new GetSendingOptionsV3ResponseTypeUnencoded();
@@ -81,7 +82,8 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link GetSendingOptionsV3ResponseTypeUnencoded.Ametikohad }
-   * 
+   *
+   * @return {@link GetSendingOptionsV3ResponseTypeUnencoded.Ametikohad}
    */
   public GetSendingOptionsV3ResponseTypeUnencoded.Ametikohad createGetSendingOptionsV3ResponseTypeUnencodedAmetikohad() {
       return new GetSendingOptionsV3ResponseTypeUnencoded.Ametikohad();
@@ -89,7 +91,8 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link GetSendingOptionsV3ResponseTypeUnencoded.Allyksused }
-   * 
+   *
+   * @return {@link GetSendingOptionsV3ResponseTypeUnencoded.Allyksused}
    */
   public GetSendingOptionsV3ResponseTypeUnencoded.Allyksused createGetSendingOptionsV3ResponseTypeUnencodedAllyksused() {
       return new GetSendingOptionsV3ResponseTypeUnencoded.Allyksused();
@@ -97,7 +100,8 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused }
-   * 
+   *
+   * @return {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused}
    */
   public GetSendingOptionsV3ResponseTypeUnencoded.Asutused createGetSendingOptionsV3ResponseTypeUnencodedAsutused() {
       return new GetSendingOptionsV3ResponseTypeUnencoded.Asutused();
@@ -105,7 +109,8 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus }
-   * 
+   *
+   * @return {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus}
    */
   public GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus createGetSendingOptionsV3ResponseTypeUnencodedAsutusedAsutus() {
       return new GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus();
@@ -113,7 +118,8 @@ public class ObjectFactory {
   
   /**
    * Create an instance of {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus.Saatmine }
-   * 
+   *
+   * @return {@link GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus.Saatmine}
    */
   public GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus.Saatmine createGetSendingOptionsV3ResponseTypeUnencodedAsutusedAsutusSaatmine() {
       return new GetSendingOptionsV3ResponseTypeUnencoded.Asutused.Asutus.Saatmine();

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/ObjectFactory.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/ObjectFactory.java
@@ -108,7 +108,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link SignatureType }
-   * 
+   *
    * @return {@link SignatureType}
    */
   public SignatureType createSignatureType() {
@@ -117,7 +117,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link SignatureValueType }
-   * 
+   *
    * @return {@link SignatureValueType}
    */
   public SignatureValueType createSignatureValueType() {
@@ -126,7 +126,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link SignedInfoType }
-   * 
+   *
    * @return {@link SignedInfoType}
    */
   public SignedInfoType createSignedInfoType() {
@@ -135,7 +135,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link CanonicalizationMethodType }
-   * 
+   *
    * @return {@link CanonicalizationMethodType}
    */
   public CanonicalizationMethodType createCanonicalizationMethodType() {
@@ -144,7 +144,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link SignatureMethodType }
-   * 
+   *
    * @return {@link SignatureMethodType}
    */
   public SignatureMethodType createSignatureMethodType() {
@@ -153,7 +153,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link ReferenceType }
-   * 
+   *
    * @return {@link ReferenceType}
    */
   public ReferenceType createReferenceType() {
@@ -162,7 +162,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link TransformsType }
-   * 
+   *
    * @return {@link TransformsType}
    */
   public TransformsType createTransformsType() {
@@ -171,7 +171,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link TransformType }
-   * 
+   *
    * @return {@link TransformType}
    */
   public TransformType createTransformType() {
@@ -180,7 +180,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link DigestMethodType }
-   * 
+   *
    * @return {@link DigestMethodType}
    */
   public DigestMethodType createDigestMethodType() {
@@ -189,7 +189,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link KeyInfoType }
-   * 
+   *
    * @return {@link KeyInfoType}
    */
   public KeyInfoType createKeyInfoType() {
@@ -198,7 +198,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link KeyValueType }
-   * 
+   *
    * @return {@link KeyValueType}
    */
   public KeyValueType createKeyValueType() {
@@ -207,7 +207,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link RetrievalMethodType }
-   * 
+   *
    * @return {@link RetrievalMethodType}
    */
   public RetrievalMethodType createRetrievalMethodType() {
@@ -216,7 +216,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link X509DataType }
-   * 
+   *
    * @return {@link X509DataType}
    */
   public X509DataType createX509DataType() {
@@ -225,7 +225,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link PGPDataType }
-   * 
+   *
    * @return {@link PGPDataType}
    */
   public PGPDataType createPGPDataType() {
@@ -234,7 +234,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link SPKIDataType }
-   * 
+   *
    * @return {@link SPKIDataType}
    */
   public SPKIDataType createSPKIDataType() {
@@ -243,7 +243,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link ObjectType }
-   * 
+   *
    * @return {@link ObjectType}
    */
   public ObjectType createObjectType() {
@@ -252,7 +252,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link ManifestType }
-   * 
+   *
    * @return {@link ManifestType}
    */
   public ManifestType createManifestType() {
@@ -261,7 +261,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link SignaturePropertiesType }
-   * 
+   *
    * @return {@link SignaturePropertiesType}
    */
   public SignaturePropertiesType createSignaturePropertiesType() {
@@ -270,7 +270,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link SignaturePropertyType }
-   * 
+   *
    * @return {@link SignaturePropertyType}
    */
   public SignaturePropertyType createSignaturePropertyType() {
@@ -279,7 +279,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link DSAKeyValueType }
-   * 
+   *
    * @return {@link DSAKeyValueType}
    */
   public DSAKeyValueType createDSAKeyValueType() {
@@ -288,7 +288,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link RSAKeyValueType }
-   * 
+   *
    * @return {@link RSAKeyValueType}
    */
   public RSAKeyValueType createRSAKeyValueType() {
@@ -297,7 +297,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link X509IssuerSerialType }
-   * 
+   *
    * @return {@link X509IssuerSerialType}
    */
   public X509IssuerSerialType createX509IssuerSerialType() {
@@ -306,7 +306,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link SignatureType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -317,7 +317,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link SignatureValueType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -329,7 +329,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link SignedInfoType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -340,7 +340,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link CanonicalizationMethodType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -353,7 +353,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link SignatureMethodType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -365,7 +365,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link ReferenceType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -376,7 +376,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link TransformsType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -387,7 +387,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link TransformType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -398,7 +398,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link DigestMethodType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -409,8 +409,8 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * 
+   * Create an instance of {@link JAXBElement }{@code <}byte[]{@code >}
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -421,7 +421,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link KeyInfoType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -432,7 +432,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -443,7 +443,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -454,7 +454,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link KeyValueType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -465,9 +465,9 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link RetrievalMethodType }{@code >}
-   * 
+   *
    * @param value value
-   * 
+   *
    * @return {@link JAXBElement}
    */
   @XmlElementDecl(namespace = "http://www.w3.org/2000/09/xmldsig#", name = "RetrievalMethod")
@@ -478,7 +478,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link X509DataType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -489,7 +489,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link PGPDataType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -500,7 +500,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link SPKIDataType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -511,7 +511,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link ObjectType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -522,7 +522,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link ManifestType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -533,7 +533,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link SignaturePropertiesType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -546,7 +546,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link SignaturePropertyType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -558,7 +558,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link DSAKeyValueType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -570,7 +570,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link RSAKeyValueType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -581,8 +581,8 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * 
+   * Create an instance of {@link JAXBElement }{@code <}byte[]{@code >}
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -593,8 +593,8 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * 
+   * Create an instance of {@link JAXBElement }{@code <}byte[]{@code >}
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -605,8 +605,8 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * 
+   * Create an instance of {@link JAXBElement }{@code <}byte[]{@code >}
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -618,7 +618,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link X509IssuerSerialType }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -630,8 +630,8 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * 
+   * Create an instance of {@link JAXBElement }{@code <}byte[]{@code >}
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -643,7 +643,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -654,8 +654,8 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * 
+   * Create an instance of {@link JAXBElement }{@code <}byte[]{@code >}
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -666,8 +666,8 @@ public class ObjectFactory {
   }
 
   /**
-   * Create an instance of {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * 
+   * Create an instance of {@link JAXBElement }{@code <}byte[]{@code >}
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -679,7 +679,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link String }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */
@@ -691,7 +691,7 @@ public class ObjectFactory {
 
   /**
    * Create an instance of {@link JAXBElement }{@code <}{@link BigInteger }{@code >}
-   * 
+   *
    * @param value value
    * @return {@link JAXBElement}
    */

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/PGPDataType.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/PGPDataType.java
@@ -92,7 +92,7 @@ public class PGPDataType {
    * 
    * <p>
    * Objects of the following type(s) are allowed in the list {@link JAXBElement
-   * }{@code <}{@link byte[]}{@code >} {@link JAXBElement }{@code <}{@link byte[]}{@code >}
+   * }{@code <}byte[]{@code >} {@link JAXBElement }{@code <}byte[]{@code >}
    * {@link Object } {@link Element }
    * 
    * @return list of {@link Object}

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/SPKIDataType.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/SPKIDataType.java
@@ -72,7 +72,7 @@ public class SPKIDataType {
    * 
    * <p>
    * Objects of the following type(s) are allowed in the list {@link JAXBElement
-   * }{@code <}{@link byte[]}{@code >} {@link Element } {@link Object }
+   * }{@code <}byte[]{@code >} {@link Element } {@link Object }
    * 
    * @return list of {@link Object}
    */

--- a/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/X509DataType.java
+++ b/dhx-adapter-server/src/main/java/ee/ria/dhx/server/types/org/w3/_2000/_09/xmldsig_/X509DataType.java
@@ -86,8 +86,8 @@ public class X509DataType {
    * 
    * <p>
    * Objects of the following type(s) are allowed in the list {@link JAXBElement
-   * }{@code <}{@link byte[]}{@code >} {@link JAXBElement }{@code <}{@link byte[]}{@code >}
-   * {@link JAXBElement } {@code <}{@link byte[]}{@code >} {@link Element } {@link JAXBElement
+   * }{@code <}byte[]{@code >} {@link JAXBElement }{@code <}byte[]{@code >}
+   * {@link JAXBElement } {@code <}byte[]{@code >} {@link Element } {@link JAXBElement
    * }{@code <} {@link X509IssuerSerialType }{@code >} {@link JAXBElement }{@code <}{@link String
    * }{@code >} {@link Object }
    * 

--- a/dhx-adapter-ws/src/main/java/ee/ria/dhx/bigdata/BigDataHandler.java
+++ b/dhx-adapter-ws/src/main/java/ee/ria/dhx/bigdata/BigDataHandler.java
@@ -135,7 +135,7 @@ public abstract class BigDataHandler implements ContentHandler {
         isDocument = true;
         BigDataXmlElement annotation = dataField.getAnnotation(BigDataXmlElement.class);
         if (annotation != null) {
-          String name = annotation.name();
+          String name = annotation.name().intern();
           qname = qname.replace(localName, name);
           localName = name;
         }

--- a/dhx-adapter-ws/src/main/java/ee/ria/dhx/ws/config/SoapConfig.java
+++ b/dhx-adapter-ws/src/main/java/ee/ria/dhx/ws/config/SoapConfig.java
@@ -603,12 +603,13 @@ public class SoapConfig {
     log.info("javax.net.ssl.keyStorePassword: {}", getClientKeyStorePassword());
     log.info("javax.net.ssl.keyStoreType: {}", getClientKeyStoreType());
 
-    ClassLoader cl = ClassLoader.getSystemClassLoader();
+    String pathSeparator = System.getProperty("path.separator");
+    String[] classPathEntries = System
+            .getProperty("java.class.path")
+            .split(pathSeparator);
 
-    URL[] urls = ((URLClassLoader)cl).getURLs();
-
-    for(URL url: urls){
-      log.info("SoapConfig.url: {}", url.getFile());
+    for(String classPathEntry: classPathEntries){
+      log.info("SoapConfig.url: {}", classPathEntry);
     }
     
     // setup truststore

--- a/docs/adapter-server-paigaldusjuhend.md
+++ b/docs/adapter-server-paigaldusjuhend.md
@@ -58,7 +58,7 @@ Minimaalne (kõik komponendid ühes serveris) paigalduse vaade on järgmine
 
 ## 2. Tarkvara nõuded (baastarkvara eeldused)
 
-* **Java SE 7**, **Java SE 8** või **Java 11**. Käivitamiseks on vajalik [Java SE 7](http://www.oracle.com/technetwork/java/javase/downloads/index.html) (või uuem) versioon.
+* **Java SE 8** või **Java 11**. Käivitamiseks on vajalik [Java SE 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html) (või uuem) versioon.
 * **Apache Tomcat 7**. Tarkvara käivitamiseks on vajalik [Apache Tomcat 7](http://tomcat.apache.org/download-70.cgi) või uuem versioon.
 * **PostgreSQL 9.6** või **Oracle 11g**. Andmebaasi serverina on soovituslik kasutada [PostgreSQL 9.6](https://www.postgresql.org/) või [Oracle 11g](http://www.oracle.com/technetwork/database/index.html) (kaasa arvatud 11g Express Edition) või uuemaid versioone.
 * Operatsioonisüsteem - Java poolt [toetatud süsteem](https://www.java.com/en/download/help/sysreq.xml).

--- a/docs/adapter-server-paigaldusjuhend.md
+++ b/docs/adapter-server-paigaldusjuhend.md
@@ -15,14 +15,18 @@ Sisukord
     * [4\. Paigaldamine](#4-paigaldamine)
       * [4\.1\. Olemasoleva paigalduspaketiga (WAR) \- Tomcat ja PostgeSQL](#41-olemasoleva-paigalduspaketiga-war---tomcat-ja-postgesql)
         * [4\.1\.1\. PostgreSQL 9\.6](#411-postgresql-96)
-        * [4\.1\.2 Java 8 SE](#412-java-8-se)
+        * [4\.1\.2\. Java SE](#412-java-se)
+        * [4\.1\.2\.1\. Java 8 SE](#4121-java-8-se)
+        * [4\.1\.2\.2\. Java 11+ SE](#4122-java-11-se)
         * [4\.1\.3\. Apache Tomcat 7](#413-apache-tomcat-7)
         * [4\.1\.4\. DHX adapterserver WAR](#414-dhx-adapterserver-war)
         * [4\.1\.5\. Muuta dhx\-application\.properties](#415-muuta-dhx-applicationproperties)
         * [4\.1\.6\. Paigaldada Tomcat Windows Servicena või Linux deemonina\.](#416-paigaldada-tomcat-windows-servicena-v%C3%B5i-linux-deemonina)
       * [4\.2\. Olemasoleva paigalduspaketiga (WAR) \- Tomcat ja Oracle 11g Express edition](#42-olemasoleva-paigalduspaketiga-war---tomcat-ja-oracle-11g-express-edition)
         * [4\.2\.1\. Oracle 11g Express Edition](#421-oracle-11g-express-edition)
-        * [4\.2\.2\. Java 8 SE](#422-java-8-se)
+        * [4\.2\.2\. Java SE](#422-java-se)
+        * [4\.2\.2\.1\. Java 8 SE](#4221-java-8-se)
+        * [4\.2\.2\.2\. Java 11+ SE](#4222-java-11-se)
         * [4\.2\.3\. Apache Tomcat 7](#423-apache-tomcat-7)
         * [4\.2\.4\. DHX adapterserver WAR](#424-dhx-adapterserver-war)
         * [4\.2\.5\. Muuta dhx\-application\.properties](#425-muuta-dhx-applicationproperties)
@@ -54,7 +58,7 @@ Minimaalne (kõik komponendid ühes serveris) paigalduse vaade on järgmine
 
 ## 2. Tarkvara nõuded (baastarkvara eeldused)
 
-* **Java SE 8** või **Java SE 7**. Käivitamiseks on vajalik [Java SE 7](http://www.oracle.com/technetwork/java/javase/downloads/index.html) (või uuem) versioon.
+* **Java SE 7**, **Java SE 8** või **Java 11**. Käivitamiseks on vajalik [Java SE 7](http://www.oracle.com/technetwork/java/javase/downloads/index.html) (või uuem) versioon.
 * **Apache Tomcat 7**. Tarkvara käivitamiseks on vajalik [Apache Tomcat 7](http://tomcat.apache.org/download-70.cgi) või uuem versioon.
 * **PostgreSQL 9.6** või **Oracle 11g**. Andmebaasi serverina on soovituslik kasutada [PostgreSQL 9.6](https://www.postgresql.org/) või [Oracle 11g](http://www.oracle.com/technetwork/database/index.html) (kaasa arvatud 11g Express Edition) või uuemaid versioone.
 * Operatsioonisüsteem - Java poolt [toetatud süsteem](https://www.java.com/en/download/help/sysreq.xml).
@@ -108,10 +112,18 @@ Anda loodud kasutajale kõik selle andmebaasi õigused.
 GRANT ALL PRIVILEGES ON DATABASE dhx_adapter to dhxuser;
 ```
 
-#### 4.1.2 Java 8 SE
+#### 4.1.2. Java SE
 
-Laadida alla ja installeerida [Java 8 SE Runtime environment](http://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html).
+##### 4.1.2.1. Java 8 SE
 
+Laadida alla ja installeerida [Java 8 SE Runtime environment](https://www.oracle.com/technetwork/java/javase/downloads/jre8-downloads-2133155.html).
+
+##### 4.1.2.2. Java 11+ SE
+
+> **!!!TÄHELEPANU!!!** Alates Oracle JDK 11-st on oluliselt muutunud Java litsents, mis lubab seda kasutada tasuta vaid **personaalseks** ja **arenduse**
+otstarbeks. Komplikatsioonide tekkimise vältimiseks kasutada [OpenJDK](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase11-5116896.html) väljalaskeid
+
+Laadida alla ja paigaldada [OpenJDK](https://www.oracle.com/technetwork/java/javase/downloads/java-archive-javase11-5116896.html).
 
 #### 4.1.3. Apache Tomcat 7
 
@@ -262,9 +274,15 @@ grant resource to dhxadapter;
 grant unlimited tablespace to dhxadapter;
 ```
 
-#### 4.2.2. Java 8 SE
+#### 4.2.2. Java SE
 
-Vaata [eespoolt](#412-java-8-se)
+##### 4.2.2.1. Java 8 SE
+
+Vaata [eespoolt](#4121-java-8-se)
+
+##### 4.2.2.2. Java 11+ SE
+
+Vaata [eespoolt](#4122-java-11-se)
 
 
 #### 4.2.3. Apache Tomcat 7

--- a/docs/java-teegid-kasutusjuhend.md
+++ b/docs/java-teegid-kasutusjuhend.md
@@ -13,6 +13,7 @@ Sisukord
     * [1\. Sissejuhatus](#1-sissejuhatus)
     * [2\. Välised sõltuvused ja baasplatvorm](#2-v%C3%A4lised-s%C3%B5ltuvused-ja-baasplatvorm)
     * [3\. Ehitamine](#3-ehitamine)
+    * [3\.1\. JDK 11+](#31-jdk-11)
     * [4\. Teadaolevad probleemid (sõltuvuste konfliktid)](#4-teadaolevad-probleemid-s%C3%B5ltuvuste-konfliktid)
     * [5\. Teegi laadimise häälestamine uuematel serveritel (annotatsioonid)](#5-teegi-laadimise-h%C3%A4%C3%A4lestamine-uuematel-serveritel-annotatsioonid)
     * [6\. Teegi laadimise häälestamine vanematel serveritel (web\.xml)](#6-teegi-laadimise-h%C3%A4%C3%A4lestamine-vanematel-serveritel-webxml)
@@ -128,6 +129,12 @@ Lisada oma tarkvara projekti ehitamise Maven pom.xml sisse järgmised sõltuvuse
 			<scope>compile</scope>
 		</dependency>
 ```
+
+### 3.1. JDK 11+
+
+Kasutades JDK 11 versiooni rakenduse ehitamisel on tarvilik kasutada `jdk11` profiili.
+
+> ```mvn install -P jdk11```
 
 ## 4. Teadaolevad probleemid (sõltuvuste konfliktid)
 

--- a/docs/java-teegid-kasutusjuhend.md
+++ b/docs/java-teegid-kasutusjuhend.md
@@ -132,7 +132,7 @@ Lisada oma tarkvara projekti ehitamise Maven pom.xml sisse järgmised sõltuvuse
 
 ### 3.1. JDK 11+
 
-Kasutades JDK 11 versiooni rakenduse ehitamisel on tarvilik kasutada `jdk11` profiili.
+Kasutades JDK 11 versiooni rakenduse ehitamisel on tarvilik kasutada `jdk11` Maven profiili.
 
 > ```mvn install -P jdk11```
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
 		<resourceDir>conf/${conf}</resourceDir>
 		<jcabi.aspectj>1.9.2</jcabi.aspectj>
 		<boot.version>1.5.17.RELEASE</boot.version>
+		<jaxb.api.version>2.3.0</jaxb.api.version>
+		<jaxws-ri.version>2.3.2</jaxws-ri.version>
 	</properties>
 	<modules>
 		<module>dhx-adapter-core</module>
@@ -205,6 +207,47 @@
 
 	</build>
 	<profiles>
+		<profile>
+			<id>jdk11</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<!-- Dependencies to make DHX build and work with JDK11 without any code changes -->
+			<dependencies>
+				<dependency>
+					<groupId>javax.xml.bind</groupId>
+					<artifactId>jaxb-api</artifactId>
+					<version>${jaxb.api.version}</version>
+				</dependency>
+				<dependency>
+					<groupId>com.sun.xml.bind</groupId>
+					<artifactId>jaxb-core</artifactId>
+					<version>${jaxb.api.version}</version>
+				</dependency>
+				<dependency>
+					<groupId>com.sun.xml.ws</groupId>
+					<artifactId>jaxws-ri</artifactId>
+					<version>${jaxws-ri.version}</version>
+					<type>pom</type>
+				</dependency>
+				<dependency>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+					<version>1.3.2</version>
+				</dependency>
+			</dependencies>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<configuration>
+							<source>8</source>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
 		<profile>
 			<id>production</id>
 			<activation>


### PR DESCRIPTION
Java 9/10 deprecated and 11 removed `javax.xml.bind.annotation` and `jaxws-ri`. Start using explicit dependencies. Doesn't harm DHX functioning with Java 8.